### PR TITLE
Add Argilla in ECS with Aurora Postgres and OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,19 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 * `npx cdk deploy`  deploy this stack to your default AWS account/region
 * `npx cdk diff`    compare deployed stack with current state
 * `npx cdk synth`   emits the synthesized CloudFormation template
+
+## Deploying Argilla in ECS with Aurora Postgres and OpenSearch
+
+This project sets up an AWS CDK v2 app to host Argilla in ECS with an Aurora Postgres setup and an AWS OpenSearch cluster.
+
+### Steps to deploy
+
+1. **Install dependencies**: Run `npm install` to install all necessary dependencies.
+2. **Build the project**: Run `npm run build` to compile the TypeScript code.
+3. **Deploy the stack**: Run `npx cdk deploy` to deploy the stack to your AWS account/region.
+
+### Resources created
+
+- **ECS Cluster**: An ECS cluster to host the Argilla container.
+- **Aurora Postgres**: An Aurora Postgres database cluster.
+- **OpenSearch**: An AWS OpenSearch cluster.

--- a/cdk.json
+++ b/cdk.json
@@ -66,6 +66,9 @@
     "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
     "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
     "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": true,
-    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false
+    "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false,
+    "@aws-cdk/aws-ecs:enableFargateCapacityProviders": true,
+    "@aws-cdk/aws-rds:auroraPostgresDefaultDatabaseName": "feedbacksystemdb",
+    "@aws-cdk/aws-opensearchservice:domainName": "feedbacksystemdomain"
   }
 }

--- a/lib/feedback-system-stack.ts
+++ b/lib/feedback-system-stack.ts
@@ -1,16 +1,69 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-// import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as rds from 'aws-cdk-lib/aws-rds';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as opensearch from 'aws-cdk-lib/aws-opensearchservice';
 
 export class FeedbackSystemStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // The code that defines your stack goes here
+    // ECS Cluster
+    const vpc = new ec2.Vpc(this, 'FeedbackSystemVpc', {
+      maxAzs: 3
+    });
 
-    // example resource
-    // const queue = new sqs.Queue(this, 'FeedbackSystemQueue', {
-    //   visibilityTimeout: cdk.Duration.seconds(300)
-    // });
+    const cluster = new ecs.Cluster(this, 'FeedbackSystemCluster', {
+      vpc: vpc
+    });
+
+    const taskDefinition = new ecs.FargateTaskDefinition(this, 'FeedbackSystemTaskDef');
+
+    const container = taskDefinition.addContainer('FeedbackSystemContainer', {
+      image: ecs.ContainerImage.fromRegistry('argilla/argilla'),
+      memoryLimitMiB: 512,
+      cpu: 256
+    });
+
+    container.addPortMappings({
+      containerPort: 80
+    });
+
+    new ecs.FargateService(this, 'FeedbackSystemService', {
+      cluster: cluster,
+      taskDefinition: taskDefinition
+    });
+
+    // Aurora Postgres
+    const dbCluster = new rds.DatabaseCluster(this, 'FeedbackSystemDbCluster', {
+      engine: rds.DatabaseClusterEngine.auroraPostgres({
+        version: rds.AuroraPostgresEngineVersion.VER_13_4
+      }),
+      instanceProps: {
+        vpc: vpc,
+        instanceType: ec2.InstanceType.of(
+          ec2.InstanceClass.BURSTABLE2,
+          ec2.InstanceSize.SMALL
+        )
+      }
+    });
+
+    // OpenSearch
+    const domain = new opensearch.Domain(this, 'FeedbackSystemDomain', {
+      version: opensearch.EngineVersion.OPENSEARCH_1_0,
+      capacity: {
+        masterNodes: 2,
+        dataNodes: 2
+      },
+      ebs: {
+        volumeSize: 20
+      },
+      nodeToNodeEncryption: true,
+      encryptionAtRest: {
+        enabled: true
+      },
+      enforceHttps: true
+    });
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "dependencies": {
     "aws-cdk-lib": "2.151.0",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "@aws-cdk/aws-ecs": "^2.151.0",
+    "@aws-cdk/aws-rds": "^2.151.0",
+    "@aws-cdk/aws-opensearchservice": "^2.151.0"
   }
 }


### PR DESCRIPTION
Add resources for hosting Argilla in ECS with Aurora Postgres and OpenSearch using AWS CDK v2.

* **package.json**
  - Add dependencies for `@aws-cdk/aws-ecs`, `@aws-cdk/aws-rds`, and `@aws-cdk/aws-opensearchservice`.

* **lib/feedback-system-stack.ts**
  - Import necessary modules for ECS, RDS, and OpenSearch.
  - Add ECS cluster and task definition for Argilla.
  - Add Aurora Postgres setup.
  - Add OpenSearch cluster setup.

* **README.md**
  - Update instructions to include deploying Argilla in ECS with Aurora Postgres and OpenSearch.

* **cdk.json**
  - Update context and configurations for ECS, Aurora Postgres, and OpenSearch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/skorfmann/argilla-aws?shareId=64bb278a-f097-4663-9bac-21f11ea48506).